### PR TITLE
Install devscripts on Travis CI to make checkbashisms script available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
   apt:
     packages:
     - libv8-3.14-dev
+    - devscripts
 notifications:
   email:
     on_success: change


### PR DESCRIPTION
In some cases there are spurious errors caused by new checks in R devel, c.f.
https://travis-ci.org/daqana/dqmagic/jobs/599668004. This is currently not the case for dqshiny, but it still makes sense to be prepared.